### PR TITLE
Fix code scanning alert no. 3: Prototype-polluting assignment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,12 @@ export function handleMove(fromX: number, fromY: number, toX: number, toY: numbe
     return;
   }
 
+  // Validate coordinates
+  if (fromX < 0 || fromX > 7 || fromY < 0 || fromY > 7 || toX < 0 || toX > 7 || toY < 0 || toY > 7) {
+    alert("Coordonnées invalides !");
+    return;
+  }
+
   const piece = board.getPiece(fromX, fromY);
 
   // Vérifie que c'est bien le tour du joueur qui joue


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/3](https://github.com/antoinegreuzard/chess-game/security/code-scanning/3)

To fix the prototype pollution issue, we need to ensure that the `fromY` and `toY` parameters are validated to be within the acceptable range of the board's dimensions (0-7). This can be achieved by adding a validation check in the `handleMove` function in `src/index.ts` before these parameters are used.

**Steps to fix the problem:**
1. Add a validation check in the `handleMove` function to ensure `fromX`, `fromY`, `toX`, and `toY` are within the range 0-7.
2. If any of these parameters are out of range, return early from the function with an appropriate error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
