### PR TITLE
Fix code scanning alert no. 10: Prototype-polluting assignment

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -107,9 +107,10 @@ export class Board {
     if (
       toY < 0 ||
       toY >= this.grid.length ||
-      ['__proto__', 'constructor', 'prototype'].includes(toY.toString())
+      ['__proto__', 'constructor', 'prototype'].includes(toY.toString()) ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromY.toString())
     ) {
-      return false; // Invalid move if toY is out of bounds or a special property name
+      return false; // Invalid move if toY or fromY is out of bounds or a special property name
     }
     const piece = this.getPiece(fromX, fromY);
 


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/10](https://github.com/antoinegreuzard/chess-game/security/code-scanning/10)

To fix the prototype pollution issue, we need to ensure that the `fromY` parameter cannot be a special property name like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a validation check for `fromY` similar to the existing check for `toY` in the `movePiece` function.

- Add a validation check for `fromY` in the `movePiece` function to ensure it is not a special property name.
- This change should be made in the `src/board.ts` file, specifically in the `movePiece` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
