### PR TITLE
Fix code scanning alert no. 4: Prototype-polluting assignment

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -107,9 +107,12 @@ export class Board {
     if (
       toY < 0 ||
       toY >= this.grid.length ||
-      ['__proto__', 'constructor', 'prototype'].includes(toY.toString())
+      fromY < 0 ||
+      fromY >= this.grid.length ||
+      ['__proto__', 'constructor', 'prototype'].includes(toY.toString()) ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromY.toString())
     ) {
-      return false; // Invalid move if toY is out of bounds or a special property name
+      return false; // Invalid move if fromY or toY is out of bounds or a special property name
     }
     const piece = this.getPiece(fromX, fromY);
 


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/4](https://github.com/antoinegreuzard/chess-game/security/code-scanning/4)

To fix the problem, we need to ensure that both `fromY` and `toY` parameters are validated to prevent them from being special property names that could lead to prototype pollution. This can be done by adding checks similar to the existing ones for `toY` in the `movePiece` method.

- Add validation checks for `fromY` and `toY` to ensure they are not `__proto__`, `constructor`, or `prototype`.
- These checks should be added in the `movePiece` method in `src/board.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
