### PR TITLE
Fix code scanning alert no. 3: Prototype-polluting assignment

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -107,9 +107,12 @@ export class Board {
     if (
       toY < 0 ||
       toY >= this.grid.length ||
-      ['__proto__', 'constructor', 'prototype'].includes(toY.toString())
+      ['__proto__', 'constructor', 'prototype'].includes(toY.toString()) ||
+      fromY < 0 ||
+      fromY >= this.grid.length ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromY.toString())
     ) {
-      return false; // Invalid move if toY is out of bounds or a special property name
+      return false; // Invalid move if toY or fromY is out of bounds or a special property name
     }
     const piece = this.getPiece(fromX, fromY);
 


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/3](https://github.com/antoinegreuzard/chess-game/security/code-scanning/3)

To fix the prototype pollution issue, we need to ensure that `fromY` is validated to prevent it from being a special property name like `__proto__`, `constructor`, or `prototype`. This can be done by adding a check similar to the one already in place for `toY`.

**Steps to fix:**
1. Add a validation check for `fromY` to ensure it is not a special property name.
2. Ensure this check is placed before any assignment or usage of `this.grid[fromY]`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
