### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -107,9 +107,12 @@ export class Board {
     if (
       toY < 0 ||
       toY >= this.grid.length ||
-      ['__proto__', 'constructor', 'prototype'].includes(toY.toString())
+      ['__proto__', 'constructor', 'prototype'].includes(toY.toString()) ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromY.toString()) ||
+      ['__proto__', 'constructor', 'prototype'].includes(toX.toString()) ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromX.toString())
     ) {
-      return false; // Invalid move if toY is out of bounds or a special property name
+      return false; // Invalid move if any coordinate is out of bounds or a special property name
     }
     const piece = this.getPiece(fromX, fromY);
 


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/2](https://github.com/antoinegreuzard/chess-game/security/code-scanning/2)

To fix the prototype pollution issue, we need to ensure that all user-controlled inputs (`fromX`, `fromY`, `toX`, `toY`) are validated to prevent them from being special property names like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding checks for these values before using them to index into `this.grid`.

1. Add validation checks for `fromX`, `fromY`, `toX`, and `toY` to ensure they are not special property names.
2. Ensure these checks are applied in the `movePiece` method and any other method that uses these values for indexing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
