### PR TITLE
Fix code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -105,11 +105,12 @@ export class Board {
     toY: number,
   ): boolean {
     if (
-      toY < 0 ||
-      toY >= this.grid.length ||
-      ['__proto__', 'constructor', 'prototype'].includes(toY.toString())
+      toY < 0 || toY >= this.grid.length ||
+      fromY < 0 || fromY >= this.grid.length ||
+      ['__proto__', 'constructor', 'prototype'].includes(toY.toString()) ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromY.toString())
     ) {
-      return false; // Invalid move if toY is out of bounds or a special property name
+      return false; // Invalid move if toY or fromY is out of bounds or a special property name
     }
     const piece = this.getPiece(fromX, fromY);
 
@@ -204,6 +205,12 @@ export class Board {
   }
 
   private handleCastling(kingX: number, kingY: number): void {
+    if (
+      kingY < 0 || kingY >= this.grid.length ||
+      ['__proto__', 'constructor', 'prototype'].includes(kingY.toString())
+    ) {
+      return; // Invalid move if kingY is out of bounds or a special property name
+    }
     // Déplacement pour le petit roque (roi se déplace vers la droite)
     if (kingX === 6) {
       const rook = this.getPiece(7, kingY);


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/9](https://github.com/antoinegreuzard/chess-game/security/code-scanning/9)

To fix the problem, we need to ensure that `fromY` and `toY` values are validated to prevent prototype pollution. This can be achieved by adding checks to ensure these values are within the valid range for a chessboard (0-7) and are not special property names like `__proto__`, `constructor`, or `prototype`.

- Add validation checks for `fromY` and `toY` in the `movePiece` method and other relevant parts of the code.
- Ensure that these checks are applied before any assignment to `this.grid`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
