### PR TITLE
Fix code scanning alert no. 8: Prototype-polluting assignment

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -107,9 +107,12 @@ export class Board {
     if (
       toY < 0 ||
       toY >= this.grid.length ||
-      ['__proto__', 'constructor', 'prototype'].includes(toY.toString())
+      ['__proto__', 'constructor', 'prototype'].includes(toY.toString()) ||
+      fromY < 0 ||
+      fromY >= this.grid.length ||
+      ['__proto__', 'constructor', 'prototype'].includes(fromY.toString())
     ) {
-      return false; // Invalid move if toY is out of bounds or a special property name
+      return false; // Invalid move if fromY or toY is out of bounds or a special property name
     }
     const piece = this.getPiece(fromX, fromY);
 


### PR DESCRIPTION
Fixes [https://github.com/antoinegreuzard/chess-game/security/code-scanning/8](https://github.com/antoinegreuzard/chess-game/security/code-scanning/8)

To fix the prototype pollution vulnerability, we need to ensure that `fromY` and `toY` cannot be set to special property names like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding checks to validate these values before using them as indices.

1. **General Fix:** Validate `fromY` and `toY` to ensure they are within the expected range and are not special property names.
2. **Detailed Fix:** Add checks in the `movePiece` method to ensure `fromY` and `toY` are valid indices.
3. **Files/Regions/Lines to Change:** Modify the `movePiece` method in `src/board.ts` to include these checks.
4. **Needed Changes:** Add validation logic for `fromY` and `toY`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
